### PR TITLE
Use latest scapy. We had fixed to 2.4.0 to avoid a build error, with the

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,7 +2,7 @@ PyYAML
 zmq
 IPython
 pyelftools
-scapy==2.4.0 #2.4.1 and 2.4.2 have build error, release 2.4.3rc3 fixes wait for official release
+scapy==2.4.4 
 pycparser
 pygdbmi==0.9.0.3  # avatar2 needs this and pygdbmi==0.10.0.0 broke compatibility 
 avatar2==1.3.1    # pinning both to prevent breaking


### PR DESCRIPTION
fix available in 2.4.3rc3. Scapy is now on 2.4.4.

Resolves #3.