### PR TITLE
Add Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,43 @@ Contents of $VIRTUAL_ENV/bin/predeactivate
 unset HALUCINATOR_QEMU
 ```
 
+## Building with Docker
+A Dockerfile which builds an image with all the required dependencies
+for Halucinator is present. 
+It can be found in the `docker/` folder.
+
+Inside the `docker/` folder are two files:
+
+* The `Dockerfile` that builds the image
+* A `Makefile` for convenience
+
+To build the image navigate to the `docker/` directory and run `make`:
+```
+$ cd path/to/Halucinator/docker/
+$ make
+```
+
+This will build the docker image locally.
+View the available images with:
+```
+$ docker image ls
+```
+
+To start a long running container with an interactive `/bin/bash` session, run:
+```
+$ make run
+```
+
+To connect to an existing, long running container, run:
+```
+$ make bash
+```
+
+To delete the container and local image crated, run:
+```
+$ make clean
+```
+
 ## Running
 
 Running Halucinator requires a configuration file that lists the functions to 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:18.04
+ARG VERSION=1
+
+LABEL name="Halucinator Testing" \
+      version="${VERSION}"
+
+WORKDIR /root/
+ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get update && apt-get install -y sudo automake python3-pip \
+	python3-dev build-essential libxml2-dev gdb gdb-multiarch \
+	libxslt1-dev git libffi-dev cmake libreadline-dev libtool debootstrap debian-archive-keyring \
+	libglib2.0-dev libpixman-1-dev screen binutils-multiarch nasm vim libssl-dev \
+	tcpdump g++ 
+
+RUN git clone --recursive https://github.com/embedded-sec/halucinator.git
+RUN ["/bin/bash", "-c", "cd /root/halucinator && pip3 install -r src/requirements.txt && pip3 install -e src"] 
+RUN ["/bin/bash", "-c", "ln /usr/bin/gdb-multiarch /usr/bin/arm-none-eabi-gdb"]
+
+# Install Avatar2 Qemu
+RUN git clone --recursive https://github.com/avatartwo/avatar2.git
+RUN ["/bin/bash", "-c", "cd /root/avatar2 && python3 setup.py install && echo yes | /root/avatar2/targets/build_qemu.sh"]
+
+ENV HALUCINATOR_QEMU="/root/avatar2/targets/build/qemu/arm-softmmu/qemu-system-arm"
+
+# To run an example, please refer to https://github.com/embedded-sec/halucinator#running-uart-example
+# Open two terminals and type the following commands:
+# Terminal 1:
+# `hal_dev_uart -i=1073811456`
+# Terminal 2:
+# `cd /root/halucinator && test/STM32/example/run.sh`

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,14 @@
+version=1.0
+
+build:
+	docker image build -t halucinator_img:${version} --build-arg VERSION=${version} .
+
+run: build
+	docker run -it --name halucinator halucinator_img:${version} /bin/bash
+
+bash:
+	docker exec -it halucinator /bin/bash
+
+clean:
+	docker rm -f halucinator
+	docker image rm halucinator_img:${version}


### PR DESCRIPTION
Add Dockerfile and Makefile to ease the process of testing Halucinator.
The image builds all the dependencies via `apt-get` and avatar2.qemu via sources from their Github repo